### PR TITLE
タスクのフィルタリング機能を追加し、FilterItemsコンポーネントにフィルタリング用のボタンを実装。初期Todoリストの状態管理を追…

### DIFF
--- a/app/components/FilterItems.tsx
+++ b/app/components/FilterItems.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
-
-const FilterItems = () => {
+interface FilterItemsProps {
+  setFilterdTodoList: (status: string) => void;
+}
+const FilterItems = ({ setFilterdTodoList }: FilterItemsProps) => {
+  const showAllTasks = () => {
+    setFilterdTodoList('all');
+  };
+  const showUncompleteTasks = () => {
+    setFilterdTodoList('uncomplete');
+  };
+  const showCompleteTasks = () => {
+    setFilterdTodoList('complete');
+  };
   return (
     <div className="mt-6 flex justify-between items-center border-t border-gray-700 pt-4">
       <div className="text-sm text-gray-400">「」件の未完了タスク</div>
       <div className="flex space-x-2">
-        <button className="placeholder:px-3 py-1 rounded-md text-xs">すべて</button>
-        <button className="px-3 py-1 rounded-md text-xs">未完了</button>
-        <button className="px-3 py-1 rounded-md text-xs">完了済み</button>
+        <button onClick={showAllTasks} className="placeholder:px-3 py-1 rounded-md text-xs">
+          すべて
+        </button>
+        <button onClick={showUncompleteTasks} className="px-3 py-1 rounded-md text-xs">
+          未完了
+        </button>
+        <button onClick={showCompleteTasks} className="px-3 py-1 rounded-md text-xs">
+          完了済み
+        </button>
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,11 @@ import FilterItems from './components/FilterItems';
 import NewTodoForm from './components/NewTodoForm';
 import TodoList from './components/TodoList';
 import { Todo } from './types/type';
+// type Status = 'all' | 'complete' | 'uncomplete';
 
 export default function Home() {
+  // const [status, setStatus] = useState<Status>('all');
+  const [initialTodoList, setInitialTodoList] = useState<Todo[] | null>([]);
   const [todoList, setTodoList] = useState<Todo[] | null>([]);
   // todo追加時にリストを更新する関数
   const updataTodoList = async (newTodo: Todo): Promise<void> => {
@@ -16,6 +19,44 @@ export default function Home() {
       }
       return [...prevTodos, newTodo];
     });
+    setInitialTodoList((prevInitialTodoList) => {
+      if (prevInitialTodoList == null) {
+        return [newTodo];
+      }
+      return [...prevInitialTodoList, newTodo];
+    });
+  };
+
+  const setFilterdTodoList = (status: string) => {
+    if (status === 'all') {
+      setTodoList(initialTodoList);
+    } else if (status === 'complete') {
+      if (initialTodoList == null) return;
+      const filterdTodoList = initialTodoList
+        .map((todo) => {
+          return {
+            task: todo.task,
+            id: todo.id,
+            createdAt: todo.createdAt,
+            complete: todo.complete,
+          };
+        })
+        .filter((todo: Todo) => todo.complete === true);
+      setTodoList(filterdTodoList);
+    } else if (status === 'uncomplete') {
+      if (initialTodoList == null) return;
+      const filterdTodoList = initialTodoList
+        .map((todo) => {
+          return {
+            task: todo.task,
+            id: todo.id,
+            createdAt: todo.createdAt,
+            complete: todo.complete,
+          };
+        })
+        .filter((todo: Todo) => todo.complete === false);
+      setTodoList(filterdTodoList);
+    }
   };
   // todoリストの取得
   useEffect(() => {
@@ -23,6 +64,7 @@ export default function Home() {
       try {
         const res = await fetch(`${process.env.NEXT_PUBLIC_LOCALHOST_URL}/api/todos`);
         const todos = await res.json();
+        setInitialTodoList(todos);
         setTodoList(todos);
       } catch (error) {
         console.error('エラーが発生しました', error);
@@ -43,7 +85,7 @@ export default function Home() {
           </div>
           <NewTodoForm updataTodoList={updataTodoList}></NewTodoForm>
           <TodoList todoList={todoList}></TodoList>
-          <FilterItems></FilterItems>
+          <FilterItems setFilterdTodoList={setFilterdTodoList}></FilterItems>
         </div>
         {/* 完了タスククリアボタン */}
         <div className="px-6 py-4 bg-gray-900 bg-opacity-60 flex justify-between items-center">


### PR DESCRIPTION
## タスクのフィルタリング機能を追加

- タスク一覧の下になるフィルターボタンを押すと、表示されるタスクが切り替わる

### 実装ロジック

1. 全体のtodoリストは`initialTodo`としてステート管理
2. フィルタリング予定のリストは`todo`としてステート管理
3. フィルターボタンそれぞれのステータスでフィルターしたtodoリストをコンポーネントに渡し、表示されるリストを更新

![image](https://github.com/user-attachments/assets/afb3e4b5-e158-4120-9e64-f4695aa3deb6)
