### PR TITLE
タスク削除時にモーダルを表示

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onOk: () => void;
+  onCancel: () => void;
+  updateTodoList: (id: string) => void;
+  id: string;
+  task: string;
+}
+
+const Modal = (props: ModalProps) => {
+  // タスク削除
+  const deleteTodo = async (e: React.MouseEvent<HTMLButtonElement>, deleteTodoId: string) => {
+    e.preventDefault();
+    await fetch(`${process.env.NEXT_PUBLIC_LOCALHOST_URL}/api/todos`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ deleteTodoId }),
+    });
+    props.updateTodoList(props.id);
+    props.onOk();
+  };
+  return props.open ? (
+    <div>
+      <div className="bg-gray-800 bg-opacity-80 backdrop-blur-lg rounded-2xl shadow-xl p-6 w-80 h-48 flex flex-col justify-center items-center absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-20">
+        <p className="text-lg text-gray-200 mb-5 text-center">「{props.task}」を削除しますか？</p>
+        <div className="flex w-full justify-center">
+          <button
+            onClick={(e) => deleteTodo(e, props.id)}
+            className="bg-blue-600 hover:bg-blue-500 text-white px-8 py-2 rounded-lg transition-colors duration-200"
+          >
+            削除する
+          </button>
+        </div>
+      </div>
+      <div
+        onClick={props.onCancel}
+        className="fixed bg-black bg-opacity-60 w-full h-full z-10 top-0 left-0"
+      ></div>
+    </div>
+  ) : (
+    <></>
+  );
+};
+export default Modal;

--- a/app/components/TodoItem.tsx
+++ b/app/components/TodoItem.tsx
@@ -1,34 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Todo } from '../types/type';
+import Modal from './Modal';
 
-const TodoItem = (todo: Todo) => {
-  const deleteTodo = async (e: React.MouseEvent<HTMLButtonElement>, deleteTodoId: string) => {
-    e.preventDefault();
-    await fetch(`${process.env.NEXT_PUBLIC_LOCALHOST_URL}/api/todos`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ deleteTodoId }),
-    });
-  };
+type TodoItemProps = {
+  todo: Todo;
+  updateTodoList: (id: string) => void;
+};
+
+const TodoItem = (props: TodoItemProps) => {
+  // モーダルの開閉
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
   return (
     <>
       <span
-        className={`flex-grow text-gray-100 ${todo.complete ? 'line-through text-gray-500' : ''}`}
+        className={`flex-grow text-gray-100 ${props.todo.complete ? 'line-through text-gray-500' : ''}`}
       >
-        {todo.task}
+        {props.todo.task}
       </span>
       <span
-        className={`mr-3 text-xs px-2 py-1 rounded-xl hover:bg-gray-500 ${todo.complete ? 'text-gray-600 border-gray-600' : 'border-white'} border`}
+        className={`mr-3 text-xs px-2 py-1 rounded-xl hover:bg-gray-500 ${props.todo.complete ? 'text-gray-600 border-gray-600' : 'border-white'} border`}
       >
-        {todo.complete ? '完了' : '未完了'}
+        {props.todo.complete ? '完了' : '未完了'}
       </span>
-      <span className="mr-3 text-xs">{todo.createdAt}</span>
+      <span className="mr-3 text-xs">{props.todo.createdAt}</span>
       <button
-        onClick={(e) => {
-          deleteTodo(e, todo.id);
-        }}
+        onClick={() => setIsModalOpen(true)}
         className="text-gray-500 hover:text-red-500 transition-colors"
       >
         <svg
@@ -46,6 +43,14 @@ const TodoItem = (todo: Todo) => {
           />
         </svg>
       </button>
+      <Modal
+        open={isModalOpen}
+        onOk={() => setIsModalOpen(false)}
+        onCancel={() => setIsModalOpen(false)}
+        id={props.todo.id}
+        task={props.todo.task}
+        updateTodoList={props.updateTodoList}
+      ></Modal>
     </>
   );
 };

--- a/app/components/TodoList.tsx
+++ b/app/components/TodoList.tsx
@@ -2,20 +2,26 @@
 import React from 'react';
 import TodoItem from './TodoItem';
 import { Todo } from '../types/type';
+
 type TodoListProps = {
   todoList: Todo[] | null;
+  updateTodoListByDelete: (id: string) => void;
 };
-function TodoList({ todoList }: TodoListProps) {
-  if (todoList == null) return <p>登録したtaskはまだありません</p>;
+
+function TodoList(props: TodoListProps) {
+  const updateTodoList = (id: string) => {
+    props.updateTodoListByDelete(id);
+  };
+  if (props.todoList == null) return <p>登録したtaskはまだありません</p>;
   return (
     <div className="space-y-2">
-      {todoList.map((todo) => (
+      {props.todoList.map((todo) => (
         <div
           key={todo.id}
           className={`p-3 rounded-lg transition-all duration-300 ${todo.complete ? 'bg-gray-800 bg-opacity-40' : 'bg-gray-800 bg-opacity-80 border-l-4 border-blue-500'}`}
         >
           <div className="flex items-center">
-            <TodoItem {...todo}></TodoItem>
+            <TodoItem todo={todo} updateTodoList={updateTodoList}></TodoItem>
           </div>
         </div>
       ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,14 +5,13 @@ import FilterItems from './components/FilterItems';
 import NewTodoForm from './components/NewTodoForm';
 import TodoList from './components/TodoList';
 import { Todo } from './types/type';
-// type Status = 'all' | 'complete' | 'uncomplete';
 
 export default function Home() {
   // const [status, setStatus] = useState<Status>('all');
   const [initialTodoList, setInitialTodoList] = useState<Todo[] | null>([]);
   const [todoList, setTodoList] = useState<Todo[] | null>([]);
   // todo追加時にリストを更新する関数
-  const updataTodoList = async (newTodo: Todo): Promise<void> => {
+  const updataTodoList = async (newTodo: Todo) => {
     setTodoList((prevTodos) => {
       if (prevTodos == null) {
         return [newTodo];
@@ -26,7 +25,21 @@ export default function Home() {
       return [...prevInitialTodoList, newTodo];
     });
   };
-
+  // todos削除時にリストを更新する関数
+  const updateTodoListByDelete = (deletedTodoId: string) => {
+    setTodoList((prevTodos) => {
+      if (prevTodos == null) {
+        return [];
+      }
+      return prevTodos.filter((todo) => todo.id !== deletedTodoId);
+    });
+    setInitialTodoList((prevInitialTodoList) => {
+      if (prevInitialTodoList == null) {
+        return [];
+      }
+      return prevInitialTodoList.filter((todo) => todo.id !== deletedTodoId);
+    });
+  };
   const setFilterdTodoList = (status: string) => {
     if (status === 'all') {
       setTodoList(initialTodoList);
@@ -84,7 +97,7 @@ export default function Home() {
             <div className="h-3 w-3 rounded-full bg-blue-500 animate-pulse"></div>
           </div>
           <NewTodoForm updataTodoList={updataTodoList}></NewTodoForm>
-          <TodoList todoList={todoList}></TodoList>
+          <TodoList todoList={todoList} updateTodoListByDelete={updateTodoListByDelete}></TodoList>
           <FilterItems setFilterdTodoList={setFilterdTodoList}></FilterItems>
         </div>
         {/* 完了タスククリアボタン */}


### PR DESCRIPTION
## タスク削除時にモーダルを表示

### 実装内容

- タスク削除時に表示するモーダルコンポーネントの作成
- タスク表示時に削除したタスクがリストから削除されるようにステートを更新

## 問題点

- 親コンポーネントにあるステート更新の実装で、関数のバケツリレーがかなりネストしてしまっている
- これに関してはステートのグローバル管理などで対応予定で、「パフォーマンス改善の実装」として行いため今回はこの実装でマージ


![image](https://github.com/user-attachments/assets/a9f8d6ef-b5fa-45dd-ae09-fab0f9698565)
